### PR TITLE
fix: light theme bg issues

### DIFF
--- a/src/components/pages/ComponentViewer/PropsWrapper.tsx
+++ b/src/components/pages/ComponentViewer/PropsWrapper.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren } from "react";
 
 function PropsWrapper({ children }: PropsWithChildren) {
   return (
-    <ScrollArea.Root className="w-96 overflow-hidden border-l border-gray-800 text-sm">
+    <ScrollArea.Root className="w-96 overflow-hidden border-l border-gray-800 text-white text-sm">
       <ScrollArea.Viewport className="h-full w-full p-8">
         {children}
       </ScrollArea.Viewport>

--- a/src/components/ui/RootLayout.tsx
+++ b/src/components/ui/RootLayout.tsx
@@ -85,7 +85,7 @@ function RootLayout() {
             key={route.href}
             to="/$component"
             params={{ component: route.href }}
-            className="rounded-lg p-2 text-gray-400 transition-all hover:bg-gray-900"
+            className="rounded-lg p-2 text-gray-300 transition-all hover:bg-gray-900"
             activeProps={{ className: "bg-gray-900 text-white" }}
             activeOptions={{
               includeSearch: false,

--- a/src/index.css
+++ b/src/index.css
@@ -12,13 +12,13 @@
   color-scheme: dark;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 255, 255, 255;
+    --foreground-rgb: 0, 0, 0;
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }


### PR DESCRIPTION
Fixed a visual bug for users with light theme enabled

Before:
<img width="1412" alt="image" src="https://github.com/victorgaard/playground/assets/13384559/79572469-d941-4fd9-931b-36069ccf4178">

After:
<img width="1412" alt="image" src="https://github.com/victorgaard/playground/assets/13384559/7811dfc1-9aad-4952-b3bd-5037e223ba15">
